### PR TITLE
Update DropTarget.pas

### DIFF
--- a/Source/DropTarget.pas
+++ b/Source/DropTarget.pas
@@ -8,9 +8,9 @@ unit DropTarget;
 // Target:          Win32, Win64, Delphi 6-XE7
 // Authors:         Anders Melander, anders@melander.dk, http://melander.dk
 // Latest Version   https://github.com/landrix/The-new-Drag-and-Drop-Component-Suite-for-Delphi
-// Copyright        © 1997-1999 Angus Johnson & Anders Melander
-//                  © 2000-2010 Anders Melander
-//                  © 2011-2015 Sven Harazim
+// Copyright        Â© 1997-1999 Angus Johnson & Anders Melander
+//                  Â© 2000-2010 Anders Melander
+//                  Â© 2011-2015 Sven Harazim
 // Changes          Add WinTarget property for running without TWinControl Target
 //                  04.09.2014 by Manfred Suesens DUERR Systems GmbH
 // -----------------------------------------------------------------------------
@@ -1401,7 +1401,7 @@ begin
   begin
     // If MultiTarget isn't enabled, Register will automatically unregister so
     // no need to do it here.
-    if (FMultiTarget) and not(csLoading in ComponentState) then
+    if (not FMultiTarget) and not(csLoading in ComponentState) then
       Unregister;
     Register(Value);
   end;


### PR DESCRIPTION
Multitarget won't work when changing Target property on TDropComboTarget. When changing the target the previous target gets unregistered.

Example:
DFM:
```
object Form4: TForm4
  Left = 0
  Top = 0
  Caption = 'Form4'
  ClientHeight = 300
  ClientWidth = 635
  Color = clBtnFace
  Font.Charset = DEFAULT_CHARSET
  Font.Color = clWindowText
  Font.Height = -11
  Font.Name = 'Tahoma'
  Font.Style = []
  OldCreateOrder = False
  OnCreate = FormCreate
  PixelsPerInch = 96
  TextHeight = 13
  object Edit1: TEdit
    Left = 40
    Top = 24
    Width = 121
    Height = 21
    TabOrder = 0
    Text = 'Edit1'
  end
  object Edit2: TEdit
    Left = 40
    Top = 64
    Width = 121
    Height = 21
    TabOrder = 1
    Text = 'Edit2'
  end
  object Edit3: TEdit
    Left = 40
    Top = 104
    Width = 121
    Height = 21
    TabOrder = 2
    Text = 'Edit3'
  end
  object DropComboTarget1: TDropComboTarget
    DragTypes = [dtCopy, dtLink]
    WinTarget = 0
    Left = 248
    Top = 48
  end
end
```

Pas:
```
unit Unit4;

interface

uses
  Windows, Messages, SysUtils, Variants, Classes, Graphics, Controls, Forms,
  Dialogs, DragDrop, DropTarget, DropComboTarget, StdCtrls;

type
  TForm4 = class(TForm)
    DropComboTarget1: TDropComboTarget;
    Edit1: TEdit;
    Edit2: TEdit;
    Edit3: TEdit;
    procedure FormCreate(Sender: TObject);
  private
    { Private-Deklarationen }
  public
    { Public-Deklarationen }
  end;

var
  Form4: TForm4;

implementation

{$R *.dfm}

procedure TForm4.FormCreate(Sender: TObject);
begin
   DropComboTarget1.MultiTarget := true;
   DropComboTarget1.Target := Edit1;
   DropComboTarget1.Target := Edit2;
   DropComboTarget1.Target := Edit3;
end;

end.
```

